### PR TITLE
Add `-nt 1` command to iqtree

### DIFF
--- a/orthofinder/config.json
+++ b/orthofinder/config.json
@@ -20,7 +20,7 @@
     
     "iqtree":{ 
     "program_type": "tree",
-    "cmd_line": "iqtree -s INPUT -pre PATH/IDENTIFIER > /dev/null",
+    "cmd_line": "iqtree -nt 1 -s INPUT -pre PATH/IDENTIFIER > /dev/null",
     "ouput_filename": "PATH/IDENTIFIER.treefile"
     },
     


### PR DESCRIPTION
The `-nt` option for `iqtree` is required but is missing from the configuration file. This change adds it and instructs `iqtree` to use a single thread.