### PR TITLE
check if stderr is byte, then encode it if it was a string

### DIFF
--- a/scripts_of/parallel_task_manager.py
+++ b/scripts_of/parallel_task_manager.py
@@ -61,6 +61,10 @@ if getattr(sys, 'frozen', False):
 
 def stderr_exempt(stderr):
     ok_line_starts = {"diamond v", "Licensed under the GNU GPL", "Check http://github.com/"}
+    try:
+        stderr = stderr.decode()
+    except (UnicodeDecodeError, AttributeError):
+        stderr = stderr.encode()
     lines = stderr.split("\n")
     for line in lines:
         if line.rstrip() == "": continue


### PR DESCRIPTION
When using `mcl` I had an error message:

> 2019-12-09 19:45:52 : Written final scores for species 22 to graph file
Traceback (most recent call last):
  File "OrthoFinder/orthofinder.py", line 7, in <module>
    main(args)
  File "/gpfs/workspace/tmp/fsapet/OrthoFinder/scripts_of/__main__.py", line 1694, in main
    DoOrthogroups(options, speciesInfoObj, seqsInfo)
  File "/gpfs/workspace/tmp/fsapet/OrthoFinder/scripts_of/__main__.py", line 1334, in DoOrthogroups
    MCL.RunMCL(graphFilename, clustersFilename, options.nProcessAlg, options.mclInflation)
  File "/gpfs/workspace/tmp/fsapet/OrthoFinder/scripts_of/__main__.py", line 211, in RunMCL
    parallel_task_manager.RunCommand(command, qShell=False, qPrintOnError=True)
  File "/gpfs/workspace/tmp/fsapet/OrthoFinder/scripts_of/parallel_task_manager.py", line 116, in RunCommand
    elif qPrintStderr and len(stderr) > 0 and not stderr_exempt(stderr):
  File "/gpfs/workspace/tmp/fsapet/OrthoFinder/scripts_of/parallel_task_manager.py", line 64, in stderr_exempt
    lines = stderr.split("\n")
TypeError: a bytes-like object is required, not 'str'

`mcl` prints `[mcl] cut <28> instances of overlap\n` and this is a string, not bytes.