### PR TITLE
rename ExampleDataset to ExampleData in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,14 +75,14 @@ setup(
     # have to be included in MANIFEST.in as well.
      package_data={
           '': ['config.json'],
-        #   'ExampleDataset': ['ExampleDataset/Mycoplasma_hyopneumoniae.faa', 'ExampleDataset/Mycoplasma_agalactiae.faa', 'ExampleDataset/Mycoplasma_gallisepticum.faa', 'ExampleDataset/Mycoplasma_genitalium.faa']
+        #   'ExampleData': ['ExampleData/Mycoplasma_hyopneumoniae.faa', 'ExampleData/Mycoplasma_agalactiae.faa', 'ExampleData/Mycoplasma_gallisepticum.faa', 'ExampleData/Mycoplasma_genitalium.faa']
      },
 
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
     # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
-    data_files=[('ExampleDataset', ['ExampleDataset/Mycoplasma_hyopneumoniae.faa', 'ExampleDataset/Mycoplasma_agalactiae.faa', 'ExampleDataset/Mycoplasma_gallisepticum.faa', 'ExampleDataset/Mycoplasma_genitalium.faa'])],
+    data_files=[('ExampleData', ['ExampleData/Mycoplasma_hyopneumoniae.faa', 'ExampleData/Mycoplasma_agalactiae.faa', 'ExampleData/Mycoplasma_gallisepticum.faa', 'ExampleData/Mycoplasma_genitalium.faa'])],
 
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow


### PR DESCRIPTION
Installing OrthoFinder 2.5.2 from source fails with:

```
  error: can't copy 'ExampleDataset/Mycoplasma_hyopneumoniae.faa': doesn't exist or not a regular file
  Building wheel for orthofinder (setup.py): finished with status 'error'                                                                                                                                     ERROR: Failed building wheel for orthofinder
```

This is caused by the renaming done in c9a1f38878dc9236ab06487f9849afdf51aecf69, which was not taken into account into the `setup.py` script...

The changes in this PR fix that issue.