### PR TITLE
Use tempfile library to handle temporal folders

### DIFF
--- a/scripts_of/__main__.py
+++ b/scripts_of/__main__.py
@@ -1315,7 +1315,7 @@ def CheckDependencies(options, prog_caller, dirForTempFiles):
     if (options.qStartFromFasta):
         if options.search_program == "blast":
             if not CanRunBLAST(): util.Fail()
-        elif not prog_caller.TestSearchMethod(dirForTempFiles, options.search_program):
+        elif not prog_caller.TestSearchMethod(options.search_program):
             print("\nERROR: Cannot run %s" % options.search_program)
             print("Format of make database command:")
             print("  " + prog_caller.GetSearchMethodCommand_DB(options.search_program, "INPUT", "OUTPUT"))

--- a/scripts_of/orthologues.py
+++ b/scripts_of/orthologues.py
@@ -623,7 +623,7 @@ def CanRunOrthologueDependencies(workingDir, qMSAGeneTrees, qPhyldog, qStopAfter
                 print("Please check MAFFT is installed and that the executables are in the system path\n")
                 return False
         elif msa_method != None:
-            if not program_caller.TestMSAMethod(temp_dir, msa_method):
+            if not program_caller.TestMSAMethod(msa_method):
                 print(("ERROR: Cannot run user-configured MSA method '%s'" % msa_method))
                 print("Please check program is installed and that it is correctly configured in the orthofinder/config.json file\n")
                 return False
@@ -633,7 +633,7 @@ def CanRunOrthologueDependencies(workingDir, qMSAGeneTrees, qPhyldog, qStopAfter
                 print("Please check FastTree is installed and that the executables are in the system path\n")
                 return False      
         elif tree_method != None:
-            if not program_caller.TestTreeMethod(temp_dir, tree_method):
+            if not program_caller.TestTreeMethod(tree_method):
                 print(("ERROR: Cannot run user-configured tree method '%s'" % tree_method))
                 print("Please check program is installed and that it is correctly configured in the orthofinder/config.json file\n")
                 return False


### PR DESCRIPTION
When running OrthoFinder in a cluster passing the data in an NFS folder, the tests are so fast that sometimes some internal files are still being deleted at the same time `shutil.rmtree()` is running, raising an error:

```
Traceback (most recent call last):
  File "/hps/software/users/ensembl/compara/jalvarez/testbench/OrthoFinder_source/orthofinder.py", line 7, in <module>
    main(args)
  File "/hps/software/users/ensembl/compara/jalvarez/testbench/OrthoFinder_source/scripts_of/__main__.py", line 1719, in main
    CheckDependencies(options, prog_caller, files.FileHandler.GetWorkingDirectory1_Read()[0])
  File "/hps/software/users/ensembl/compara/jalvarez/testbench/OrthoFinder_source/scripts_of/__main__.py", line 1310, in CheckDependencies
    elif not prog_caller.TestSearchMethod(dirForTempFiles, options.search_program):
  File "/hps/software/users/ensembl/compara/jalvarez/testbench/OrthoFinder_source/scripts_of/program_caller.py", line 199, in TestSearchMethod
    shutil.rmtree(d)
  File "/hps/software/users/ensembl/compara/shared/pyenv/versions/3.9.5/lib/python3.9/shutil.py", line 718, in rmtree
    _rmtree_safe_fd(fd, path, onerror)
  File "/hps/software/users/ensembl/compara/shared/pyenv/versions/3.9.5/lib/python3.9/shutil.py", line 675, in _rmtree_safe_fd
    onerror(os.unlink, fullname, sys.exc_info())
  File "/hps/software/users/ensembl/compara/shared/pyenv/versions/3.9.5/lib/python3.9/shutil.py", line 673, in _rmtree_safe_fd
    os.unlink(entry.name, dir_fd=topfd)
FileNotFoundError: [Errno 2] No such file or directory: '.nfs491292b75b71b1300002134e'
```

Since this temporary folder is only meant to be alive for the time of the test(s), I have moved this code inside a context manager using `tempfile`. This way the system handles the cleanup on its own, and gives the user more control over where the tests are run (via `$TMPDIR`, for instance).