### PR TITLE
Set the default number of threads to the number of CPUs/cores the process is really allowed to use

### DIFF
--- a/scripts_of/util.py
+++ b/scripts_of/util.py
@@ -38,7 +38,7 @@ except ImportError:
 import multiprocessing as mp
 from collections import namedtuple
 
-nThreadsDefault = mp.cpu_count()
+nThreadsDefault = len(os.sched_getaffinity(0))
 
 from . import tree, parallel_task_manager
 


### PR DESCRIPTION
Hello,

  Some of our users execute OrthoFinder on our Linux HPC cluster which runs under Slum Scheduler. Here is the problem: even if the user sets -c/--cpus-per-task option correctly, OrthoFinder doesn't take it into account. The default "parallel sequence search threads" remains the total number of cores of the compute node OrthoFinder is running on instead of the number of cores the OrthoFinder process can really use on that node (set by the Slurm option in our case and enforced by cgroup). 
  
  OrthoFinder can't take that enforcement into account because nThreadsDefault is computed using os.cpu_count() in scripts_of/util.py rather than len(os.sched_getaffinity(0)).

  Would you consider changing the way nThreadsDefault is set? I know sched_getaffinity doesn't exist in Python 2.7 but maybe you are planning to drop the python 2.7 support in a future release?

  Thanks in advance,