### PR TITLE
Specify version in docker pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ via bioconda: `conda install orthofinder`
 The easiest way to run OrthoFinder on Windows is using the Windows Subsystem for Linux or Docker: [davidemms/orthofinder](https://hub.docker.com/r/davidemms/orthofinder): 
 
 ```
-docker pull davidemms/orthofinder
+docker pull davidemms/orthofinder:2.5.4
 docker run -it --rm davidemms/orthofinder orthofinder -h
 docker run --ulimit nofile=1000000:1000000 -it --rm -v /full/path/to/fastas:/input:Z davidemms/orthofinder orthofinder -f /input
 ```


### PR DESCRIPTION
Hello,
Hope you are well! Here is a small change to the README, which may or may not be the best way to get around my error.

Pulling the docker image with the command `docker pull davidemms/orthofinder` defaults to the tag `latest`, which does not exist:

```
(orthofinder)
 ✘  Wed 24 Nov - 12:27  ~/Downloads 
 @olgabot  docker pull davidemms/orthofinder
Using default tag: latest
Error response from daemon: manifest for davidemms/orthofinder:latest not found: manifest unknown: manifest unknown
```

However, I was able to get the docker image to pull by specifying the version:

```
(orthofinder)
 ✘  Wed 24 Nov - 12:27  ~/Downloads 
 @olgabot  docker pull davidemms/orthofinder:2.5.4
2.5.4: Pulling from davidemms/orthofinder
dc65f448a2e2: Pull complete
67e6f9a1a951: Pull complete
9cf157065a7e: Pull complete
2905c80ac474: Pull complete
7e78fde5f3d5: Pull complete
d8790fe86402: Pull complete
c1989620753b: Pull complete
ba1f76799d10: Pull complete
52798560e2e4: Pull complete
bb2fbce10f9d: Pull complete
853250527709: Pull complete
9f2105aa5472: Pull complete
30904ce9c7b5: Pull complete
Digest: sha256:0219d7989633ed70bc8be9d7cd79e854eff08377bc67d8ba0533bfeaad0b593d
Status: Downloaded newer image for davidemms/orthofinder:2.5.4
docker.io/davidemms/orthofinder:2.5.4
```

In my opinion, either the README can be updated to specify a tag, or the Docker repository can be updated to point `latest` to the current most recent tag.

Thank you!
Warmest,
Olga