### PR TITLE
allow valid symlinks

### DIFF
--- a/scripts_of/__main__.py
+++ b/scripts_of/__main__.py
@@ -1575,7 +1575,16 @@ def ProcessesNewFasta(fastaDir, q_dna, speciesInfoObj_prev = None, speciesToUse_
     if not os.path.exists(fastaDir):
         print("\nDirectory does not exist: %s" % fastaDir)
         util.Fail()
-    files_in_directory = sorted([f for f in os.listdir(fastaDir) if os.path.isfile(os.path.join(fastaDir,f))])
+
+    def points_to_file(file: str) -> bool:
+        full_path = os.path.join(fastaDir, file)
+        if os.path.isfile(full_path):
+            return True
+        if os.path.islink(full_path) and os.path.exists(full_path):
+            return True
+        return False
+
+    files_in_directory = sorted([f for f in os.listdir(fastaDir) if points_to_file(f)])
     originalFastaFilenames = []
     excludedFiles = []
     for f in files_in_directory:


### PR DESCRIPTION
So far, OrthoFinder only recognized real files that end in `{"fa", "faa", "fasta", "fas", "pep"}`.

With this patch, valid symlinks are also recognized. It seems to work, but I only tested it once on my dataset.