### PR TITLE
Update setup.py to include create_files_for_hogs.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,8 @@ setup(
             'orthofinder=scripts_of.__main__:main',
             'primary_transcript=tools.primary_transcript:main',
             'make_ultrametric=tools.make_ultrametric:main',
-            'convert_orthofinder_tree_ids=tools.convert_orthofinder_tree_ids:main'
+            'convert_orthofinder_tree_ids=tools.convert_orthofinder_tree_ids:main',
+            'create_files_for_hogs=tools.create_files_for_hogs:main'
         ],
     },
 )


### PR DESCRIPTION
From the tools directory, the create_files_for_hogs script is not included in the conda bundle. From what I've seen on the codebase, this seems solvable by a simple add to the setup.py file